### PR TITLE
Use more descriptive help for output arg

### DIFF
--- a/bnptool/__main__.py
+++ b/bnptool/__main__.py
@@ -80,7 +80,7 @@ def main():
 
     c_parser = subparses.add_parser('create', description='Create a BNP', aliases=['c'])
     c_parser.add_argument('mod', help='Path of the mod\'s directory or zip')
-    c_parser.add_argument('--output', '-o', help='Filename of the BNP to create')
+    c_parser.add_argument('--output', '-o', help='The path to the BNP file to create')
     c_parser.add_argument('--name', '-n', help='Name of the mod')
     c_parser.add_argument('--version', help='Version of the mod')
     c_parser.add_argument('--description', '-d', help='Description of the mod')

--- a/bnptool/__main__.py
+++ b/bnptool/__main__.py
@@ -80,7 +80,7 @@ def main():
 
     c_parser = subparses.add_parser('create', description='Create a BNP', aliases=['c'])
     c_parser.add_argument('mod', help='Path of the mod\'s directory or zip')
-    c_parser.add_argument('--output', '-o', help='Where to output the BNP')
+    c_parser.add_argument('--output', '-o', help='Filename of BNP to create')
     c_parser.add_argument('--name', '-n', help='Name of the mod')
     c_parser.add_argument('--version', help='Version of the mod')
     c_parser.add_argument('--description', '-d', help='Description of the mod')

--- a/bnptool/__main__.py
+++ b/bnptool/__main__.py
@@ -80,7 +80,7 @@ def main():
 
     c_parser = subparses.add_parser('create', description='Create a BNP', aliases=['c'])
     c_parser.add_argument('mod', help='Path of the mod\'s directory or zip')
-    c_parser.add_argument('--output', '-o', help='Filename of BNP to create')
+    c_parser.add_argument('--output', '-o', help='Filename of the BNP to create')
     c_parser.add_argument('--name', '-n', help='Name of the mod')
     c_parser.add_argument('--version', help='Version of the mod')
     c_parser.add_argument('--description', '-d', help='Description of the mod')


### PR DESCRIPTION
When I was reading the help, I wasn't sure if `output` expected a filename or a directory.

"Filename of the BNP to create" is more descriptive than "Where to output the BNP" as it indicates a path to a file rather than a path to a directory or file.